### PR TITLE
Update manifest.bioimage.io.yaml

### DIFF
--- a/manifest.bioimage.io.yaml
+++ b/manifest.bioimage.io.yaml
@@ -25,10 +25,12 @@ config:
 
 collection:
   - id: HPA-Classification
+    name: HPA-Classification
     type: application
     source: >-
       https://raw.githubusercontent.com/imjoy-team/imjoy-plugins/master/repository/HPA-Classification.imjoy.html
   - id: HPAShuffleNetV2
+    name: HPA ShuffleNetV2
     type: model
     rdf_source: >-
       https://raw.githubusercontent.com/bioimage-io/tfjs-bioimage-io/master/models/HPAShuffleNetV2/HPAShuffleNetV2.model.yaml


### PR DESCRIPTION
This PR adds names to some resources which currently default to the collection name.
note: the two models should be uploaded to zenodo.org instead
